### PR TITLE
Add checkbox example Issue #6

### DIFF
--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -28,6 +28,11 @@ f.input :name, :wrapper => :prepend, :label => false do %>
   f.input_field :name
 end </pre>
 
+    <%= f.input  :published, :as => :boolean %>
+
+    <pre>
+f.input :published, :as => :boolean</pre>
+
     <%= f.input :content_type, :collection => content_type_options,
                 :hint => "simple select box" %>
     <pre> f.input :content_type, :collection => content_type_options, :hint => "simple select box" </pre>

--- a/db/migrate/20111214200432_add_published_to_articles.rb
+++ b/db/migrate/20111214200432_add_published_to_articles.rb
@@ -1,0 +1,5 @@
+class AddPublishedToArticles < ActiveRecord::Migration
+  def change
+    add_column :articles, :published, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110925042740) do
+ActiveRecord::Schema.define(:version => 20111214200432) do
 
   create_table "articles", :force => true do |t|
     t.string   "name"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(:version => 20110925042740) do
     t.datetime "updated_at"
     t.string   "content_type"
     t.string   "disabled_text"
+    t.boolean  "published"
   end
 
   create_table "comments", :force => true do |t|


### PR DESCRIPTION
Follow up of https://github.com/rafaelfranca/simple_form-bootstrap/issues/6
Add a migration with the new :published field and the example with the
checkbox to enable/disable the field.
