### PR TITLE
Custom inputs for boolean, check_boxes and radio_buttons. Also other layout fixes.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -52,6 +52,20 @@ article .content {
   display: inline-block;
 }
 
+.form-vertical .form-group .control-label {
+  display: block;
+  float: none;
+}
+
+.form-vertical .form-group .col-lg-6 {
+  float: none;
+}
+
+.form-vertical .form-group .radio.radio-inline,
+.form-vertical .form-group .checkbox.checkbox-inline {
+  margin-top: 0;
+}
+
 .footer {
   padding: 70px 0;
   margin-top: 70px;

--- a/app/inputs/bs3_boolean_input.rb
+++ b/app/inputs/bs3_boolean_input.rb
@@ -1,0 +1,22 @@
+class BS3BooleanInput < SimpleForm::Inputs::BooleanInput
+  def label
+    out = <<-EOS
+      <label class="control-label col-lg-2"></label>
+    EOS
+    out.html_safe
+  end
+
+  def input
+    out = <<-EOS
+      <div class="checkbox">
+        #{build_hidden_field_for_checkbox}
+        <label>
+          #{build_check_box_without_hidden_field}
+          #{label_text}
+        </label>
+      </div>
+    EOS
+    out.gsub!(/form-control/, '')
+    out.html_safe
+  end
+end

--- a/app/inputs/bs3_collection_check_boxes_input.rb
+++ b/app/inputs/bs3_collection_check_boxes_input.rb
@@ -1,0 +1,7 @@
+class BS3CollectionCheckBoxesInput < SimpleForm::Inputs::CollectionCheckBoxesInput
+  def build_nested_boolean_style_item_tag(collection_builder)
+    out = collection_builder.check_box + collection_builder.text
+    out.gsub!(/form-control/, '')
+    out.html_safe
+  end
+end

--- a/app/inputs/bs3_collection_radio_buttons_input.rb
+++ b/app/inputs/bs3_collection_radio_buttons_input.rb
@@ -1,0 +1,12 @@
+class BS3CollectionRadioButtonsInput < SimpleForm::Inputs::CollectionRadioButtonsInput
+  def apply_nested_boolean_collection_options!(options)
+    options[:item_wrapper_tag] = :div
+  end
+
+  def build_nested_boolean_style_item_tag(collection_builder)
+    out = collection_builder.radio_button + collection_builder.text
+    out = "<label>#{out}</label>"
+    out.gsub!(/form-control/, '')
+    out.html_safe
+  end
+end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -10,11 +10,11 @@
 <%= simple_form_for @article, :html => { :class => 'form-horizontal' } do |f| %>
 <pre class='prettyprint linenums lang-rb'>
 # If you generated the SimpleForm configuration with `--bootstrap`, the `simple_form_for` helper will use the bootstrap wrapper by default.
-simple_form_for(@article, :html =&gt; { :class =&gt; 'form-horizontal' }) do |f|
+simple_form_for(@article, :html => { :class => 'form-horizontal' }) do |f|
 </pre>
 
   <% if notification = f.error_notification %>
-    <div class="alert alert-error fade in">
+    <div class="alert alert-danger fade in">
       <a class="close" data-dismiss="alert" href="#">&times;</a>
       <%= notification %>
     </div>
@@ -25,11 +25,11 @@ simple_form_for(@article, :html =&gt; { :class =&gt; 'form-horizontal' }) do |f|
               :hint => "add your article title here" %>
 <pre class='prettyprint linenums lang-rb'>
   # You can use the same `span*` classes from the grid system.
-  f.input :name, :input_html =&gt; { :class =&gt; "span6" }, :hint =&gt; "add your article title here"
+  f.input :name, :input_html => { :class => "span6" }, :hint => "add your article title here"
 </pre>
 
   <div class="form-group">
-    <div class='input-group col-lg-offset-1 col-lg-4'>
+    <div class='input-group col-lg-offset-2 col-lg-4'>
       <%= content_tag :span, "Name", :class => "input-group-addon" %>
       <%= f.input_field :name %>
     </div>
@@ -37,83 +37,74 @@ simple_form_for(@article, :html =&gt; { :class =&gt; 'form-horizontal' }) do |f|
 
 <pre class='prettyprint linenums lang-rb'>
   # Use different wrappers to use other elements from Bootstrap, like a 'prepend' box.
-  f.input :name, :wrapper =&gt; :prepend, :label =&gt; false do
-    content_tag :span, "Name", :class =&gt; "add-on"
+  f.input :name, :wrapper => :prepend, :label => false do
+    content_tag :span, "Name", :class => "input-group-addon"
     f.input_field :name
   end
 </pre>
 
-  <div class="form-group">
-    <div class="checkbox">
-      <div class="col-lg-offset-1 col-lg-10">
-        <%= f.label :published do %>
-          <%= f.check_box :published %>
-          Published
-        <% end -%>
-      </div>
-    </div>
-  </div>
+<%= f.input :published, :as => :boolean %>
 
 <pre class='prettyprint linenums lang-rb'>
-  f.input :published, :as =&gt; :boolean
+  f.input :published, :as => :boolean
 </pre>
 
   <%= f.input :content_type, :collection => content_type_options, :as => :check_boxes, :label => 'Stacked checkboxes' %>
 <pre class='prettyprint linenums lang-rb'>
-  f.input :content_type, :collection =&gt; content_type_options, :as =&gt; :check_boxes
+  f.input :content_type, :collection => content_type_options, :as => :check_boxes
 </pre>
 
-  <%= f.input :content_type, :collection => content_type_options, :as => :check_boxes, :item_wrapper_class => 'inline', :label => 'Inline checkboxes' %>
+  <%= f.input :content_type, :collection => content_type_options, :as => :check_boxes, :item_wrapper_class => 'checkbox-inline', :label => 'Inline checkboxes' %>
 <pre class='prettyprint linenums lang-rb'>
-  f.input :content_type, :collection =&gt; content_type_options, :as =&gt; :check_boxes, :item_wrapper_class =&gt; &#x27inline&#x27;
+  f.input :content_type, :collection => content_type_options, :as => :check_boxes, :item_wrapper_class => 'checkbox-inline'
 </pre>
 
   <%= f.input :content_type, :collection => content_type_options, :as => :radio_buttons, :label => 'Stacked radios' %>
 
 <pre class='prettyprint linenums lang-rb'>
-  f.input :content_type, :collection =&gt; content_type_options, :as =&gt; :radio_buttons
+  f.input :content_type, :collection => content_type_options, :as => :radio_buttons
 </pre>
 
 
-  <%= f.input :content_type, :collection => content_type_options, :as => :radio_buttons, :item_wrapper_class => 'inline', :label => 'Inline radios' %>
+  <%= f.input :content_type, :collection => content_type_options, :as => :radio_buttons, :item_wrapper_class => 'radio-inline', :label => 'Inline radios' %>
 
 <pre class='prettyprint linenums lang-rb'>
-  f.input :content_type, :collection =&gt; content_type_options, :as =&gt; :radio_buttons, :item_wrapper_class =&gt; &#x27;inline&#x27;
+  f.input :content_type, :collection => content_type_options, :as => :radio_buttons, :item_wrapper_class => 'radio-inline'
 </pre>
 
   <%= f.input :content_type, :collection => content_type_options,
               :hint => "multiple select", :input_html => { :multiple => true } %>
 <pre class='prettyprint linenums lang-rb'>
-  f.input :content_type, :collection =&gt; content_type_options, :input_html =&gt; { :multiple =&gt; true }
+  f.input :content_type, :collection => content_type_options, :input_html => { :multiple => true }
 </pre>
 
   <%= f.input :category, :collection => content_type_options,
               :hint => "simple select box" %>
 <pre class='prettyprint linenums lang-rb'>
-  f.input :category, :collection =&gt; content_type_options, :hint =&gt; "simple select box"
+  f.input :category, :collection => content_type_options, :hint => "simple select box"
 </pre>
 
   <%= f.input :content, :input_html => { :class => "span6" } %>
 <pre class='prettyprint linenums lang-rb'>
-  f.input :content, :input_html =&gt; { :class =&gt; "span6" }
+  f.input :content, :input_html => { :class => "span6" }
 </pre>
 
   <%= f.input :disabled_text, :disabled => true,
               :hint => "an example of disabled input" %>
 
 <pre class='prettyprint linenums lang-rb'>
-  f.input :disabled_text, :disabled =&gt; true, :hint =&gt; "an example of disabled input"
+  f.input :disabled_text, :disabled => true, :hint => "an example of disabled input"
 </pre>
 
   <%= f.input :disabled_text, :wrapper => :prepend, :hint => 'This is the hint text' do %>
-    <%= content_tag :span, :class => "add-on" do %>
+    <%= content_tag :span, :class => "input-group-addon" do %>
       <%= check_box_tag :remove, 'true' %>
     <% end %>
     <%= f.input_field :disabled_text, :disabled => true %>
   <% end %>
 <pre class='prettyprint linenums lang-rb'>
-f.input :disabled_text, :wrapper =&gt; :prepend, :hint =&gt; "This is the hint text" do
-  content_tag :span, :class =&gt; "add-on" do
+f.input :disabled_text, :wrapper => :prepend, :hint => "This is the hint text" do
+  content_tag :span, :class => "input-group-addon" do
     check_box_tag :remove, 'true'
   end
   f.input_field :disabled_text
@@ -122,16 +113,16 @@ end
 
   <%= f.input :disabled_text, :wrapper => :append, :hint => 'This is the hint text' do %>
     <%= f.input_field :disabled_text, :class => :mini, :disabled => true %>
-    <%= content_tag :span, :class => "add-on active" do %>
+    <%= content_tag :span, :class => "input-group-addon active" do %>
       <%= check_box_tag :remove, 'true' %>
     <% end %>
   <% end %>
 
 <pre class='prettyprint linenums lang-rb'>
   # Use the 'append' wrapper the same way as the 'prepend' one.
-  f.input :disabled_text, :wrapper =&gt; :append, :hint =&gt; "This is the hint text" do
-    f.input_field :disabled_text, :class =&gt; :mini
-    content_tag :span, :class =&gt; "add-on active" do
+  f.input :disabled_text, :wrapper => :append, :hint => "This is the hint text" do
+    f.input_field :disabled_text, :class => :mini
+    content_tag :span, :class => "input-group-addon active" do
       check_box_tag :remove, 'true'
     end
   end
@@ -143,7 +134,8 @@ end
   </div>
 <pre class='prettyprint linenums lang-rb'>
   # SimpleForm buttons already receive the 'btn' class for Bootstrap.
-  f.button :submit, :class =&gt; 'btn-primary'
-  submit_tag 'Cancel', :type =&gt; :reset, :class =&gt; "btn btn-danger"
+  f.button :submit, :class => 'btn-primary'
+  submit_tag 'Cancel', :type => :reset, :class => "btn btn-danger"
 </pre>
+
 <% end %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -45,40 +45,40 @@ SimpleForm.setup do |config|
     b.use :error, :wrap_with => { :tag => :span, :class => :error }
   end
 
-  config.wrappers :bootstrap, :tag => 'div', :class => 'form-group', :error_class => 'error' do |b|
+  config.wrappers :bootstrap, :tag => 'div', :class => 'form-group', :error_class => 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.use :label
     b.wrapper :tag => 'div', :class => 'col-lg-6' do |ba|
       ba.use :input
-      ba.use :error, :wrap_with => { :tag => 'span', :class => 'help-inline' }
+      ba.use :error, :wrap_with => { :tag => 'span', :class => 'help-block has-error' }
       ba.use :hint,  :wrap_with => { :tag => 'p', :class => 'help-block' }
     end
   end
 
-  config.wrappers :prepend, :tag => 'div', :class => "form-group", :error_class => 'error' do |b|
+  config.wrappers :prepend, :tag => 'div', :class => "form-group", :error_class => 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.use :label
-    b.wrapper :tag => 'div', :class => 'controls' do |input|
-      input.wrapper :tag => 'div', :class => 'input-prepend' do |prepend|
+    b.wrapper :tag => 'div', :class => 'controls col-lg-6' do |input|
+      input.wrapper :tag => 'div', :class => 'input-group' do |prepend|
         prepend.use :input
       end
       input.use :hint,  :wrap_with => { :tag => 'span', :class => 'help-block' }
-      input.use :error, :wrap_with => { :tag => 'span', :class => 'help-inline' }
+      input.use :error, :wrap_with => { :tag => 'span', :class => 'help-block has-error' }
     end
   end
 
-  config.wrappers :append, :tag => 'div', :class => "form-group", :error_class => 'error' do |b|
+  config.wrappers :append, :tag => 'div', :class => "form-group", :error_class => 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.use :label
-    b.wrapper :tag => 'div', :class => 'controls' do |input|
-      input.wrapper :tag => 'div', :class => 'input-append' do |append|
+    b.wrapper :tag => 'div', :class => 'controls col-lg-6' do |input|
+      input.wrapper :tag => 'div', :class => 'input-group' do |append|
         append.use :input
       end
       input.use :hint,  :wrap_with => { :tag => 'span', :class => 'help-block' }
-      input.use :error, :wrap_with => { :tag => 'span', :class => 'help-inline' }
+      input.use :error, :wrap_with => { :tag => 'span', :class => 'help-block has-error' }
     end
   end
 
@@ -133,7 +133,7 @@ SimpleForm.setup do |config|
   # config.label_text = lambda { |label, required| "#{required} #{label}" }
 
   # You can define the class to use on all labels. Default is nil.
-  config.label_class = 'control-label'
+  config.label_class = 'control-label col-lg-2'
   config.input_class = 'form-control'
 
   # You can define the class to use on all forms. Default is simple_form.
@@ -174,4 +174,11 @@ SimpleForm.setup do |config|
 
   # Cache SimpleForm inputs discovery
   # config.cache_discovery = !Rails.env.development?
+end
+module SimpleForm
+  class FormBuilder
+    map_type :boolean, to: BS3BooleanInput
+    map_type :check_boxes, to: BS3CollectionCheckBoxesInput
+    map_type :radio_buttons, to: BS3CollectionRadioButtonsInput
+  end
 end


### PR DESCRIPTION
Patched input mappings in initializer so simpleform uses custom constructions for boolean, check_boxes and radio_buttons.

Fixes:
- Boolean inputs (as: :boolean)
- CollectionRadioButtons (as: :radio_buttons)
- CollectionCheckBoxes (as: check_boxes)
- Fix inline view for both collections, also fixed display of first item
  to have the propper margin-top.
- Added 2 columns width to labels to display pretty for horizontal form.
- Fixed input-preppend, input-append and add-on
- Fix error classes for inputs, its errors and the flash.
- Added some css to application.css so vertical form displays nicely.

I based my custom inputs on the code found here to override the mappings:
https://github.com/plataformatec/simple_form/blob/master/lib/simple_form/form_builder.rb
And the necessary methods to override from the inputs directory:
https://github.com/plataformatec/simple_form/tree/master/lib/simple_form/inputs

Please, let me know what you think and if it is helpful/mergeable :)
