### PR TITLE
Changing bootstrap error class to has-error

### DIFF
--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -44,7 +44,7 @@ SimpleForm.setup do |config|
     b.use :error, :wrap_with => { :tag => :span, :class => :error }
   end
 
-  config.wrappers :bootstrap, :tag => 'div', :class => 'form-group', :error_class => 'error' do |b|
+  config.wrappers :bootstrap, :tag => 'div', :class => 'form-group', :error_class => 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.use :label, class: 'control-label'


### PR DESCRIPTION
I needed this for validation errors to be styled properly. See here: http://getbootstrap.com/css/#forms-control-validation

This is related to pr #28 but if there is a preferred way for me to submit changes, let me know.
