### PR TITLE
Tweaks to example forms for visual parity (related to pr #28)

### DIFF
--- a/app/views/examples/_basic_example_sf.html.erb
+++ b/app/views/examples/_basic_example_sf.html.erb
@@ -4,9 +4,9 @@
   file: :vertical_file_input,
   boolean: :vertical_boolean
 } do |f| %>
-  <%= f.input :my_email, as: :string, label: 'Email Address' %>
+  <%= f.input :my_email, as: :string, label: 'Email Address', placeholder: 'Enter email' %>
 
-  <%= f.input :my_password, as: :password, label: 'Password' %>
+  <%= f.input :my_password, as: :password, label: 'Password', placeholder: 'Password' %>
 
   <%= f.input :my_file, as: :file, label: 'File input' %>
 

--- a/app/views/examples/_horizontal_form_sf.html.erb
+++ b/app/views/examples/_horizontal_form_sf.html.erb
@@ -4,9 +4,9 @@
   file: :horizontal_file_input,
   boolean: :horizontal_boolean
 } do |f| %>
-  <%= f.input :my_email, as: :string, label: 'Email' %>
+  <%= f.input :my_email, as: :string, label: 'Email', placeholder: 'Email' %>
 
-  <%= f.input :my_password, as: :password, label: 'Password' %>
+  <%= f.input :my_password, as: :password, label: 'Password', placeholder: 'Password' %>
 
   <%= f.input :my_file, as: :file, label: 'File input' %>
 

--- a/app/views/examples/_inline_form_tb.html.erb
+++ b/app/views/examples/_inline_form_tb.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="checkbox">
     <label>
-      <input type="checkbox">Remember me
+      <input type="checkbox"> Remember me
     </label>
   </div>
   <button type="submit" class="btn btn-default">Sign in</button>


### PR DESCRIPTION
Tweaked a few small aspects of the example forms for visual parity and
styling across Bootstrap form and SimpleForm: placeholders and remember
me checkboxes.

Related to review performed towards finalizing open pull request #28 
