### PR TITLE
Detail Simple Form required version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This is a example application using [Simple Form](https://github.com/plataformatec/simple_form)
 and [Bootstrap](http://getbootstrap.com/).
+Require Simple Form >= 3.1.0.rc1
 
 ## License
 


### PR DESCRIPTION
I had trouble figuring out why bootstrap installation wasn't working, turns out the default Simple Form gem is v 3.0.2, for now, and 3.1.0 is required.
