### PR TITLE
Improve date, time, and datetime Bootstrap layout

### DIFF
--- a/app/assets/stylesheets/simple_form-bootstrap/_form_multi_select.scss
+++ b/app/assets/stylesheets/simple_form-bootstrap/_form_multi_select.scss
@@ -1,9 +1,0 @@
-.custom-select,
-.form-control {
-  &.date,
-  &.datetime,
-  &.time {
-    &:first-of-type { margin-left: 0 !important; }
-    &:last-of-type { margin-right: 0 !important; }
-  }
-}

--- a/app/assets/stylesheets/simple_form-bootstrap/_form_multi_select.scss
+++ b/app/assets/stylesheets/simple_form-bootstrap/_form_multi_select.scss
@@ -7,11 +7,3 @@
     &:last-of-type { margin-right: 0 !important; }
   }
 }
-
-.custom-select {
-  &[multiple],
-  &:only-child {
-    margin-left: 0 !important;
-    margin-right: 0 !important;
-  }
-}

--- a/app/assets/stylesheets/simple_form-bootstrap/_simple_form-bootstrap.scss
+++ b/app/assets/stylesheets/simple_form-bootstrap/_simple_form-bootstrap.scss
@@ -2,4 +2,3 @@
 @import "form_button";
 @import "form_collection_label";
 @import "form_floating_labels";
-@import "form_multi_select";

--- a/app/views/documentation/index.html.erb
+++ b/app/views/documentation/index.html.erb
@@ -91,9 +91,6 @@
 
       <% file_path = 'app/assets/stylesheets/simple_form-bootstrap/_form_floating_labels.scss' %>
       <%= render_source File.read(File.join(Rails.root, file_path)), :scss, file_path %>
-
-      <% file_path = 'app/assets/stylesheets/simple_form-bootstrap/_form_multi_select.scss' %>
-      <%= render_source File.read(File.join(Rails.root, file_path)), :scss, file_path %>
     </div>
   </div>
 </div>

--- a/app/views/examples/customs/_bootstrap.html.erb
+++ b/app/views/examples/customs/_bootstrap.html.erb
@@ -3,8 +3,8 @@
 
   <div class="form-group">
     <label class="form-control-label">Birthday</label>
-    <div class="d-flex flex-row justify-content-between align-items-center">
-      <select id="exampleInputDateYear" class="custom-select mr-1" required>
+    <div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap">
+      <select id="exampleInputDateYear" class="custom-select col-3 mw-100 flex-grow-1 flex-shrink-1" required>
         <option></option>
         <option value="2013">2013</option>
         <option value="2014">2014</option>
@@ -18,8 +18,8 @@
         <option value="2022">2022</option>
         <option value="2023">2023</option>
       </select>
-
-      <select id="exampleInputDateMonth" class="custom-select mx-1" required>
+      <div class="mx-1"></div>
+      <select id="exampleInputDateMonth" class="custom-select col-5 mw-100 flex-grow-1 flex-shrink-1" required>
         <option></option>
         <option value="1">January</option>
         <option value="2">February</option>
@@ -34,8 +34,8 @@
         <option value="11">November</option>
         <option value="12">December</option>
       </select>
-
-      <select id="exampleInputDateDay" class="custom-select ml-1" required>
+      <div class="mx-1"></div>
+      <select id="exampleInputDateDay" class="custom-select col-2 mw-100 flex-grow-1 flex-shrink-1" required>
         <option></option>
         <option value="1">1</option>
         <option value="2">2</option>
@@ -254,8 +254,8 @@
 
   <div class="form-group">
     <label class="form-control-label">Awake</label>
-    <div class="d-flex flex-row justify-content-between align-items-center">
-      <select id="exampleInputTimeHour" class="custom-select mr-1" required>
+    <div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap">
+      <select id="exampleInputTimeHour" class="custom-select col-2 mw-100 flex-grow-1 flex-shrink-1" required>
         <option></option>
         <option value="00">00</option>
         <option value="01">01</option>
@@ -282,8 +282,8 @@
         <option value="22">22</option>
         <option value="23">23</option>
       </select>
-      :
-      <select id="exampleInputTimeMinute" class="custom-select ml-1" required>
+      <div class="mx-1">:</div>
+      <select id="exampleInputTimeMinute" class="custom-select col-2 mw-100 flex-grow-1 flex-shrink-1" required>
         <option></option>
         <option value="00">00</option>
         <option value="30">30</option>
@@ -296,8 +296,8 @@
 
   <div class="form-group">
     <label class="form-control-label">First kiss</label>
-    <div class="d-flex flex-row justify-content-between align-items-center">
-      <select id="exampleInputDatetimeYear" class="custom-select mr-1" required>
+    <div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap mt-n1">
+      <select id="exampleInputDatetimeYear" class="custom-select col-3 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
         <option></option>
         <option value="2013">2013</option>
         <option value="2014">2014</option>
@@ -311,8 +311,8 @@
         <option value="2022">2022</option>
         <option value="2023">2023</option>
       </select>
-
-      <select id="exampleInputDatetimeMonth" class="custom-select mx-1" required>
+      <div class="mx-1"></div>
+      <select id="exampleInputDatetimeMonth" class="custom-select col-5 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
         <option></option>
         <option value="1">January</option>
         <option value="2">February</option>
@@ -327,8 +327,8 @@
         <option value="11">November</option>
         <option value="12">December</option>
       </select>
-
-      <select id="exampleInputDatetimeDay" class="custom-select mx-1" required>
+      <div class="mx-1"></div>
+      <select id="exampleInputDatetimeDay" class="custom-select col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
         <option></option>
         <option value="1">1</option>
         <option value="2">2</option>
@@ -362,8 +362,8 @@
         <option value="30">30</option>
         <option value="31">31</option>
       </select>
-      —
-      <select id="exampleInputDatetimeHour" class="custom-select mx-1" required>
+      <div class="col-2 mw-100 flex-shrink-1 text-center mt-1">&mdash;</div>
+      <select id="exampleInputDatetimeHour" class="custom-select col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
         <option></option>
         <option value="00">00</option>
         <option value="01">01</option>
@@ -390,8 +390,8 @@
         <option value="22">22</option>
         <option value="23">23</option>
       </select>
-      :
-      <select id="exampleInputDatetimeMinute" class="custom-select ml-1" required>
+      <div class="mx-1">:</div>
+      <select id="exampleInputDatetimeMinute" class="custom-select col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
         <option></option>
         <option value="00">00</option>
         <option value="30">30</option>

--- a/app/views/examples/customs/_form.html.erb
+++ b/app/views/examples/customs/_form.html.erb
@@ -8,7 +8,7 @@
     radio_buttons: :custom_collection,
     range:         :custom_range,
     time:          :custom_multi_select,
-    select:        :custom_multi_select
+    select:        :custom_select
   } do |f| %>
 
   <%= f.error_notification %>

--- a/app/views/examples/horizontals/_bootstrap.html.erb
+++ b/app/views/examples/horizontals/_bootstrap.html.erb
@@ -54,8 +54,8 @@
   <div class="form-group row">
     <label class="col-sm-3 form-control-label">Birthday</label>
     <div class="col-sm-9">
-      <div class="d-flex flex-row justify-content-between align-items-center">
-        <select id="exampleInputDateYear" class="form-control mr-1" required>
+      <div class="d-flex flex-row align-items-center flex-wrap">
+        <select id="exampleInputDateYear" class="form-control col-3 mw-100 flex-grow-1 flex-shrink-1" required>
           <option></option>
           <option value="2013">2013</option>
           <option value="2014">2014</option>
@@ -69,8 +69,8 @@
           <option value="2022">2022</option>
           <option value="2023">2023</option>
         </select>
-
-        <select id="exampleInputDateMonth" class="form-control mx-1" required>
+        <div class="mx-1"></div>
+        <select id="exampleInputDateMonth" class="form-control col-5 mw-100 flex-grow-1 flex-shrink-1" required>
           <option></option>
           <option value="1">January</option>
           <option value="2">February</option>
@@ -85,8 +85,8 @@
           <option value="11">November</option>
           <option value="12">December</option>
         </select>
-
-        <select id="exampleInputDateDay" class="form-control ml-1" required>
+        <div class="mx-1"></div>
+        <select id="exampleInputDateDay" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1" required>
           <option></option>
           <option value="1">1</option>
           <option value="2">2</option>
@@ -320,8 +320,8 @@
   <div class="form-group row">
     <label class="col-sm-3 form-control-label">Awake</label>
     <div class="col-sm-9">
-      <div class="d-flex flex-row justify-content-between align-items-center">
-        <select id="exampleInputTimeHour" class="form-control mr-1" required>
+      <div class="d-flex flex-row align-items-center flex-wrap">
+        <select id="exampleInputTimeHour" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1" required>
           <option></option>
           <option value="00">00</option>
           <option value="01">01</option>
@@ -348,8 +348,8 @@
           <option value="22">22</option>
           <option value="23">23</option>
         </select>
-        :
-        <select id="exampleInputTimeMinute" class="form-control ml-1" required>
+        <div class="mx-1">:</div>
+        <select id="exampleInputTimeMinute" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1" required>
           <option></option>
           <option value="00">00</option>
           <option value="30">30</option>
@@ -364,8 +364,8 @@
   <div class="form-group row">
     <label class="col-sm-3 form-control-label">First kiss</label>
     <div class="col-sm-9">
-      <div class="d-flex flex-row justify-content-between align-items-center">
-        <select id="exampleInputDatetimeYear" class="form-control mr-1" required>
+      <div class="d-flex flex-row align-items-center flex-wrap mt-n1">
+        <select id="exampleInputDatetimeYear" class="form-control col-3 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
           <option></option>
           <option value="2013">2013</option>
           <option value="2014">2014</option>
@@ -379,8 +379,8 @@
           <option value="2022">2022</option>
           <option value="2023">2023</option>
         </select>
-
-        <select id="exampleInputDatetimeMonth" class="form-control mx-1" required>
+        <div class="mx-1"></div>
+        <select id="exampleInputDatetimeMonth" class="form-control col-5 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
           <option></option>
           <option value="1">January</option>
           <option value="2">February</option>
@@ -395,8 +395,8 @@
           <option value="11">November</option>
           <option value="12">December</option>
         </select>
-
-        <select id="exampleInputDatetimeDay" class="form-control mx-1" required>
+        <div class="mx-1"></div>
+        <select id="exampleInputDatetimeDay" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
           <option></option>
           <option value="1">1</option>
           <option value="2">2</option>
@@ -430,8 +430,8 @@
           <option value="30">30</option>
           <option value="31">31</option>
         </select>
-        —
-        <select id="exampleInputDatetimeHour" class="form-control mx-1" required>
+        <div class="col-2 mw-100 flex-shrink-1 text-center mt-1">&mdash;</div>
+        <select id="exampleInputDatetimeHour" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
           <option></option>
           <option value="00">00</option>
           <option value="01">01</option>
@@ -458,8 +458,8 @@
           <option value="22">22</option>
           <option value="23">23</option>
         </select>
-        :
-        <select id="exampleInputDatetimeMinute" class="form-control ml-1" required>
+        <div class="mx-1">:</div>
+        <select id="exampleInputDatetimeMinute" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
           <option></option>
           <option value="00">00</option>
           <option value="30">30</option>

--- a/app/views/examples/verticals/_bootstrap.html.erb
+++ b/app/views/examples/verticals/_bootstrap.html.erb
@@ -43,8 +43,8 @@
 
   <div class="form-group">
     <label class="form-control-label">Birthday</label>
-    <div class="d-flex flex-row justify-content-between align-items-center">
-      <select id="exampleInputDateYear" class="form-control mr-1" required>
+    <div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap">
+      <select id="exampleInputDateYear" class="form-control col-3 mw-100 flex-grow-1 flex-shrink-1" required>
         <option></option>
         <option value="2013">2013</option>
         <option value="2014">2014</option>
@@ -58,8 +58,8 @@
         <option value="2022">2022</option>
         <option value="2023">2023</option>
       </select>
-
-      <select id="exampleInputDateMonth" class="form-control mx-1" required>
+      <div class="mx-1"></div>
+      <select id="exampleInputDateMonth" class="form-control col-5 mw-100 flex-grow-1 flex-shrink-1" required>
         <option></option>
         <option value="1">January</option>
         <option value="2">February</option>
@@ -74,8 +74,8 @@
         <option value="11">November</option>
         <option value="12">December</option>
       </select>
-
-      <select id="exampleInputDateDay" class="form-control ml-1" required>
+      <div class="mx-1"></div>
+      <select id="exampleInputDateDay" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1" required>
         <option></option>
         <option value="1">1</option>
         <option value="2">2</option>
@@ -291,8 +291,8 @@
 
   <div class="form-group">
     <label class="form-control-label">Awake</label>
-    <div class="d-flex flex-row justify-content-between align-items-center">
-      <select id="exampleInputTimeHour" class="form-control mr-1" required>
+    <div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap">
+      <select id="exampleInputTimeHour" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1" required>
         <option></option>
         <option value="00">00</option>
         <option value="01">01</option>
@@ -319,8 +319,8 @@
         <option value="22">22</option>
         <option value="23">23</option>
       </select>
-      :
-      <select id="exampleInputTimeMinute" class="form-control ml-1" required>
+      <div class="mx-1">:</div>
+      <select id="exampleInputTimeMinute" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1" required>
         <option></option>
         <option value="00">00</option>
         <option value="30">30</option>
@@ -333,8 +333,8 @@
 
   <div class="form-group">
     <label class="form-control-label">First kiss</label>
-    <div class="d-flex flex-row justify-content-between align-items-center">
-      <select id="exampleInputDatetimeYear" class="form-control mr-1" required>
+    <div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap mt-n1">
+      <select id="exampleInputDatetimeYear" class="form-control col-3 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
         <option></option>
         <option value="2013">2013</option>
         <option value="2014">2014</option>
@@ -348,8 +348,8 @@
         <option value="2022">2022</option>
         <option value="2023">2023</option>
       </select>
-
-      <select id="exampleInputDatetimeMonth" class="form-control mx-1" required>
+      <div class="mx-1"></div>
+      <select id="exampleInputDatetimeMonth" class="form-control col-5 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
         <option></option>
         <option value="1">January</option>
         <option value="2">February</option>
@@ -364,8 +364,8 @@
         <option value="11">November</option>
         <option value="12">December</option>
       </select>
-
-      <select id="exampleInputDatetimeDay" class="form-control mx-1" required>
+      <div class="mx-1"></div>
+      <select id="exampleInputDatetimeDay" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
         <option></option>
         <option value="1">1</option>
         <option value="2">2</option>
@@ -399,8 +399,8 @@
         <option value="30">30</option>
         <option value="31">31</option>
       </select>
-      —
-      <select id="exampleInputDatetimeHour" class="form-control mx-1" required>
+      <div class="col-2 mw-100 flex-shrink-1 text-center mt-1">&mdash;</div>
+      <select id="exampleInputDatetimeHour" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
         <option></option>
         <option value="00">00</option>
         <option value="01">01</option>
@@ -427,8 +427,8 @@
         <option value="22">22</option>
         <option value="23">23</option>
       </select>
-      :
-      <select id="exampleInputDatetimeMinute" class="form-control ml-1" required>
+      <div class="mx-1">:</div>
+      <select id="exampleInputDatetimeMinute" class="form-control col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" required>
         <option></option>
         <option value="00">00</option>
         <option value="30">30</option>

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -335,6 +335,16 @@ SimpleForm.setup do |config|
     b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
   end
 
+  # custom select
+  config.wrappers :custom_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'form-control-label'
+    b.use :input, class: 'custom-select', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
   # custom multi select
   config.wrappers :custom_multi_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
     b.use :html5
@@ -434,6 +444,7 @@ SimpleForm.setup do |config|
   #   file:          :custom_file,
   #   radio_buttons: :custom_collection,
   #   range:         :custom_range,
+  #   select:        :custom_select,
   #   time:          :custom_multi_select
   # }
 end

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -45,6 +45,19 @@ SimpleForm.setup do |config|
   config.input_field_error_class = 'is-invalid'
   config.input_field_valid_class = 'is-valid'
 
+  # Configure layout of date input, time input, and datetime input.
+  SimpleForm::Inputs::DateTimeInput.default_options.tap do |options|
+    options[:date_separator] = '<div class="mx-1"></div>'
+    options[:time_separator] = '<div class="mx-1">:</div>'
+    options[:datetime_separator] = '<div class="col-2 mw-100 flex-shrink-1 text-center mt-1">&mdash;</div>'
+    options[:with_css_classes] = {
+      year: "col-3 mw-100 flex-grow-1 flex-shrink-1 mt-1",
+      month: "col-5 mw-100 flex-grow-1 flex-shrink-1 mt-1",
+      day: "col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1",
+      hour: "col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1",
+      minute: "col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1",
+    }
+  end
 
   # vertical forms
   #
@@ -117,8 +130,8 @@ SimpleForm.setup do |config|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'form-control-label'
-    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
-      ba.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.wrapper tag: 'div', class: 'd-flex flex-row align-items-center flex-wrap flex-md-nowrap mt-n1' do |ba|
+      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
     end
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
     b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
@@ -218,8 +231,8 @@ SimpleForm.setup do |config|
     b.optional :readonly
     b.use :label, class: 'col-sm-3 control-label'
     b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |bb|
-        bb.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.wrapper tag: 'div', class: 'd-flex flex-row align-items-center flex-wrap mt-n1' do |bb|
+        bb.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
       end
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
       ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
@@ -350,8 +363,8 @@ SimpleForm.setup do |config|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'form-control-label'
-    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
-      ba.use :input, class: 'custom-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.wrapper tag: 'div', class: 'd-flex flex-row align-items-center flex-wrap flex-md-nowrap mt-n1' do |ba|
+      ba.use :input, class: 'custom-select', error_class: 'is-invalid', valid_class: 'is-valid'
     end
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
     b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }

--- a/test/simple_form-bootstrap/date_fields_test.rb
+++ b/test/simple_form-bootstrap/date_fields_test.rb
@@ -16,8 +16,8 @@ class DateFieldsTest < ActionView::TestCase
     expected = <<-HTML
       <div class="form-group date required user_birthday">
         <label class="form-control-label date required" for="user_birthday_1i">Birthday <abbr title="required">*</abbr></label>
-        <div class="d-flex flex-row justify-content-between align-items-center">
-          <select class="form-control mx-1 date required" id="user_birthday_1i" name="user[birthday(1i)]">
+        <div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap mt-n1">
+          <select class="form-control date required col-3 mw-100 flex-grow-1 flex-shrink-1 mt-1" id="user_birthday_1i" name="user[birthday(1i)]">
             <option value="2010">2010</option>
             <option value="2011">2011</option>
             <option value="2012">2012</option>
@@ -30,7 +30,8 @@ class DateFieldsTest < ActionView::TestCase
             <option value="2019">2019</option>
             <option value="2020">2020</option>
           </select>
-          <select class="form-control mx-1 date required" id="user_birthday_2i" name="user[birthday(2i)]">
+          <div class="mx-1"></div>
+          <select class="form-control date required col-5 mw-100 flex-grow-1 flex-shrink-1 mt-1" id="user_birthday_2i" name="user[birthday(2i)]">
             <option value="1">January</option>
             <option value="2">February</option>
             <option value="3">March</option>
@@ -44,7 +45,8 @@ class DateFieldsTest < ActionView::TestCase
             <option value="11">November</option>
             <option value="12">December</option>
           </select>
-          <select class="form-control mx-1 date required" id="user_birthday_3i" name="user[birthday(3i)]">
+          <div class="mx-1"></div>
+          <select class="form-control date required col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" id="user_birthday_3i" name="user[birthday(3i)]">
             <option value="1">1</option>
             <option value="2">2</option>
             <option value="3">3</option>
@@ -89,9 +91,24 @@ class DateFieldsTest < ActionView::TestCase
     expected = <<-HTML
       <div class="form-group datetime required user_first_kiss">
         <label class="form-control-label datetime required" for="user_first_kiss_1i">First kiss <abbr title="required">*</abbr></label>
-        <div class="d-flex flex-row justify-content-between align-items-center"><select class="form-control mx-1 datetime required" id="user_first_kiss_1i" name="user[first_kiss(1i)]"><option value="2010">2010</option><option value="2011">2011</option><option value="2012">2012</option><option value="2013">2013</option><option value="2014">2014</option><option selected="selected" value="2015">2015</option><option value="2016">2016</option><option value="2017">2017</option><option value="2018">2018</option><option value="2019">2019</option><option value="2020">2020</option></select><select class="form-control mx-1 datetime required" id="user_first_kiss_2i" name="user[first_kiss(2i)]"><option value="1">January</option><option value="2">February</option><option value="3">March</option><option value="4">April</option><option value="5">May</option><option value="6">June</option><option value="7">July</option><option value="8">August</option><option value="9">September</option><option selected="selected" value="10">October</option><option value="11">November</option><option value="12">December</option></select><select class="form-control mx-1 datetime required" id="user_first_kiss_3i" name="user[first_kiss(3i)]"><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option><option value="9">9</option><option value="10">10</option><option value="11">11</option><option value="12">12</option><option value="13">13</option><option value="14">14</option><option value="15">15</option><option value="16">16</option><option value="17">17</option><option value="18">18</option><option value="19">19</option><option value="20">20</option><option selected="selected" value="21">21</option><option value="22">22</option><option value="23">23</option><option value="24">24</option><option value="25">25</option><option value="26">26</option><option value="27">27</option><option value="28">28</option><option value="29">29</option><option value="30">30</option><option value="31">31</option></select>
-        <select class="form-control mx-1 datetime required" id="user_first_kiss_4i" name="user[first_kiss(4i)]"><option value="00">00</option><option value="01">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option selected="selected" value="07">07</option><option value="08">08</option><option value="09">09</option><option value="10">10</option><option value="11">11</option><option value="12">12</option><option value="13">13</option><option value="14">14</option><option value="15">15</option><option value="16">16</option><option value="17">17</option><option value="18">18</option><option value="19">19</option><option value="20">20</option><option value="21">21</option><option value="22">22</option><option value="23">23</option></select>
-        : <select class="form-control mx-1 datetime required" id="user_first_kiss_5i" name="user[first_kiss(5i)]"><option value="00">00</option><option value="30">30</option></select>
+        <div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap mt-n1">
+          <select class="form-control datetime required col-3 mw-100 flex-grow-1 flex-shrink-1 mt-1" id="user_first_kiss_1i" name="user[first_kiss(1i)]">
+              <option value="2010">2010</option><option value="2011">2011</option><option value="2012">2012</option><option value="2013">2013</option><option value="2014">2014</option><option selected="selected" value="2015">2015</option><option value="2016">2016</option><option value="2017">2017</option><option value="2018">2018</option><option value="2019">2019</option><option value="2020">2020</option>
+          </select>
+          <div class="mx-1"></div>
+          <select class="form-control datetime required col-5 mw-100 flex-grow-1 flex-shrink-1 mt-1" id="user_first_kiss_2i" name="user[first_kiss(2i)]">
+            <option value="1">January</option><option value="2">February</option><option value="3">March</option><option value="4">April</option><option value="5">May</option><option value="6">June</option><option value="7">July</option><option value="8">August</option><option value="9">September</option><option selected="selected" value="10">October</option><option value="11">November</option><option value="12">December</option>
+          </select>
+          <div class="mx-1"></div>
+          <select class="form-control datetime required col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" id="user_first_kiss_3i" name="user[first_kiss(3i)]">
+            <option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option><option value="9">9</option><option value="10">10</option><option value="11">11</option><option value="12">12</option><option value="13">13</option><option value="14">14</option><option value="15">15</option><option value="16">16</option><option value="17">17</option><option value="18">18</option><option value="19">19</option><option value="20">20</option><option selected="selected" value="21">21</option><option value="22">22</option><option value="23">23</option><option value="24">24</option><option value="25">25</option><option value="26">26</option><option value="27">27</option><option value="28">28</option><option value="29">29</option><option value="30">30</option><option value="31">31</option>
+          </select>
+          <div class="col-2 mw-100 flex-shrink-1 text-center mt-1">&mdash;</div>
+          <select class="form-control datetime required col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" id="user_first_kiss_4i" name="user[first_kiss(4i)]">
+            <option value="00">00</option><option value="01">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option selected="selected" value="07">07</option><option value="08">08</option><option value="09">09</option><option value="10">10</option><option value="11">11</option><option value="12">12</option><option value="13">13</option><option value="14">14</option><option value="15">15</option><option value="16">16</option><option value="17">17</option><option value="18">18</option><option value="19">19</option><option value="20">20</option><option value="21">21</option><option value="22">22</option><option value="23">23</option>
+          </select>
+          <div class="mx-1">:</div>
+          <select class="form-control datetime required col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" id="user_first_kiss_5i" name="user[first_kiss(5i)]"><option value="00">00</option><option value="30">30</option></select>
         </div>
         <small class="form-text text-muted">Datetime multi select example</small>
       </div>
@@ -104,8 +121,15 @@ class DateFieldsTest < ActionView::TestCase
     expected = <<-HTML
       <div class="form-group time required user_awake">
         <label class="form-control-label time required" for="user_awake_4i">Awake <abbr title="required">*</abbr></label>
-        <div class="d-flex flex-row justify-content-between align-items-center"><input id="user_awake_1i" name="user[awake(1i)]" type="hidden" value="2015"/><input id="user_awake_2i" name="user[awake(2i)]" type="hidden" value="10"/><input id="user_awake_3i" name="user[awake(3i)]" type="hidden" value="21"/><select class="form-control mx-1 time required" id="user_awake_4i" name="user[awake(4i)]"><option value="00">00</option><option value="01">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option selected="selected" value="07">07</option><option value="08">08</option><option value="09">09</option><option value="10">10</option><option value="11">11</option><option value="12">12</option><option value="13">13</option><option value="14">14</option><option value="15">15</option><option value="16">16</option><option value="17">17</option><option value="18">18</option><option value="19">19</option><option value="20">20</option><option value="21">21</option><option value="22">22</option><option value="23">23</option></select>
-        : <select class="form-control mx-1 time required" id="user_awake_5i" name="user[awake(5i)]"><option value="00">00</option><option value="30">30</option></select>
+        <div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap mt-n1">
+          <input id="user_awake_1i" name="user[awake(1i)]" type="hidden" value="2015"/><input id="user_awake_2i" name="user[awake(2i)]" type="hidden" value="10"/><input id="user_awake_3i" name="user[awake(3i)]" type="hidden" value="21"/>
+          <select class="form-control time required col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" id="user_awake_4i" name="user[awake(4i)]">
+            <option value="00">00</option><option value="01">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option selected="selected" value="07">07</option><option value="08">08</option><option value="09">09</option><option value="10">10</option><option value="11">11</option><option value="12">12</option><option value="13">13</option><option value="14">14</option><option value="15">15</option><option value="16">16</option><option value="17">17</option><option value="18">18</option><option value="19">19</option><option value="20">20</option><option value="21">21</option><option value="22">22</option><option value="23">23</option>
+          </select>
+          <div class="mx-1">:</div>
+          <select class="form-control time required col-2 mw-100 flex-grow-1 flex-shrink-1 mt-1" id="user_awake_5i" name="user[awake(5i)]">
+            <option value="00">00</option><option value="30">30</option>
+          </select>
         </div>
         <small class="form-text text-muted">Time multi select example</small>
       </div>


### PR DESCRIPTION
The previous method of styling added margins around date, time, and datetime inputs which required extra (user-supplied) CSS to remove in order to have the inputs line up with their labels. Additionally, the default sizing of the component select boxes (e.g. year, month, day) made the inputs illegible on mobile.

This patch preserves spacing between component select boxes while keeping inputs lined up with their labels (without requiring extra CSS). It also changes the relative sizing of the component select boxes to better reflect their content, and adds controlled wrapping on mobile to ensure legibility.

---

This is a companion to plataformatec/simple_form#1587.  When I made that PR, #56 had not yet been merged, but plataformatec/simple_form#1569 had been.  Now that #56 is merged, I am porting the proposed changes here too.