### PR TITLE
Add support for textarea with floating_labels_form

### DIFF
--- a/app/assets/stylesheets/simple_form-bootstrap/_form_floating_labels.scss
+++ b/app/assets/stylesheets/simple_form-bootstrap/_form_floating_labels.scss
@@ -14,6 +14,7 @@ $sf-floating-input-padding-y: $input-padding-y * 2 !default;
   height: 3.125rem;
 }
 
+.form-label-group > textarea,
 .form-label-group > input,
 .form-label-group > select,
 .form-label-group > label {
@@ -37,6 +38,7 @@ $sf-floating-input-padding-y: $input-padding-y * 2 !default;
     user-select: none;
   }
 
+  textarea,
   select,
   input {
     &::placeholder {
@@ -83,6 +85,7 @@ $sf-floating-input-padding-y: $input-padding-y * 2 !default;
     > label {
       display: none;
     }
+    textarea::-ms-input-placeholder,
     input::-ms-input-placeholder {
       color: #777;
     }
@@ -95,6 +98,7 @@ $sf-floating-input-padding-y: $input-padding-y * 2 !default;
     > label {
       display: none;
     }
+    textarea:-ms-input-placeholder,
     input:-ms-input-placeholder {
       color: #777;
     }


### PR DESCRIPTION
Textarea doesn't currently work with the floating_labels_form simple_form wrapper. When you enter text, it displays under the label (which is also the front color and size).

Broken and fixed versions showed here: https://imgur.com/a/TR0IOym

Tested on Chrome and Firefox. Unable to test on Edge/IE, but I think the change made to the fallback for those browsers will work.