### PR TITLE
add textarea example markup to floating_labels

### DIFF
--- a/app/views/examples/floating_labels/_bootstrap.html.erb
+++ b/app/views/examples/floating_labels/_bootstrap.html.erb
@@ -49,6 +49,14 @@
     <small class="form-text text-muted">Collection select example</small>
   </div>
 
+  <div class="form-label-group">
+    <textarea class="form-control" id="exampleTextareaBio" rows="2" placeholder="Tell us your story" required></textarea>
+    <label for="exampleTextareaBio">Bio</label>
+    <div class="invalid-feedback">Please provide a valid value.</div>
+    <div class="valid-feedback">Looks good!</div>
+    <small class="form-text text-muted">Textarea input example</small>
+  </div>
+
   <button type="submit" class="btn btn-primary">Create User!</button>
   <button type="reset" class="btn btn-outline-secondary">Cancel</button>
 </form>

--- a/app/views/examples/floating_labels/_form.html.erb
+++ b/app/views/examples/floating_labels/_form.html.erb
@@ -7,7 +7,7 @@
   <%= f.error_notification %>
 
   <%= render partial: "shared/form_unused_as_hidden", locals: {
-    f: f, fields: [:name, :avatar, :bio, :birthday, :color, :fruit, :pill, :choises, :active, :friends, :mood, :awake, :first_kiss]
+    f: f, fields: [:name, :avatar, :birthday, :color, :fruit, :pill, :choises, :active, :friends, :mood, :awake, :first_kiss]
   } %>
 
   <%= f.input :email %>
@@ -17,6 +17,8 @@
   <%= f.input :music, collection: User::MUSIC, input_html: { multiple: true } %>
 
   <%= f.input :language, collection: User::LANGUAGE, prompt: :translate %>
+
+  <%= f.input :bio %>
 
   <%= f.button :submit, class: "btn-primary" %>
   <%= f.button :button, "Cancel", type: "reset", class: "btn-outline-secondary" %>

--- a/test/simple_form-bootstrap/floating_labels_test.rb
+++ b/test/simple_form-bootstrap/floating_labels_test.rb
@@ -64,4 +64,16 @@ class FloatingLabelsFormTest < ActionView::TestCase
     HTML
     assert_xml_equal expected, actual
   end
+
+  def test_textarea_field
+    actual = @builder.input(:bio)
+    expected = <<-HTML
+      <div class="form-label-group text optional user_bio">
+        <textarea class="form-control text optional" id="user_bio" name="user[bio]" placeholder="Tell us your story"></textarea>
+        <label class="text optional" for="user_bio">Bio</label>
+        <small class="form-text text-muted">Textarea input example</small>
+      </div>
+    HTML
+    assert_xml_equal expected, actual
+  end
 end


### PR DESCRIPTION
add textarea example markup to floating_labels

prepare for https://github.com/rafaelfranca/simple_form-bootstrap/pull/303